### PR TITLE
Fixed bug when uploading file more than 20mb

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,10 +18,10 @@ module.exports.getFileExtension = async (ctx, fileType) => {
             return '.jpg';
         case 'document':
             fileId = ctx.message.document.file_id;
-            fileInfo = await ctx.telegram.getFile(fileId);
             extension = '';
-            if (fileInfo.file_path.includes('.')) {
-                extension = '.'+fileInfo.file_path.split('.').pop();
+            if (ctx.message.document.file_name.includes('.')) {
+                let fileNameSplit = ctx.message.document.file_name.split('.');
+                extension = '.' + fileNameSplit[fileNameSplit.length - 1];
             }
             return extension;
         case 'video':

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,7 +20,7 @@ module.exports.getFileExtension = async (ctx, fileType) => {
             fileId = ctx.message.document.file_id;
             extension = '';
             if (ctx.message.document.file_name.includes('.')) {
-                let fileNameSplit = ctx.message.document.file_name.split('.');
+                const fileNameSplit = ctx.message.document.file_name.split('.');
                 extension = '.' + fileNameSplit[fileNameSplit.length - 1];
             }
             return extension;


### PR DESCRIPTION
API call for telegram.getFile(fileId) will fail when uploading file more than 20mb. Replaced with simple split function to get file extension